### PR TITLE
Fix build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(name: "swift-nio-ip", url: "https://github.com/PSchmiedmayer/Swift-NIO-IP.git", from: "0.0.1")
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "lifx",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),

--- a/Sources/lifx/LIFX.swift
+++ b/Sources/lifx/LIFX.swift
@@ -4,7 +4,7 @@ import Logging
 import NIO
 import NIOLIFX
 
-
+@main
 struct LIFX: ParsableCommand {
     enum InitialAction: String, Codable, ExpressibleByArgument {
         case on
@@ -110,5 +110,3 @@ struct LIFX: ParsableCommand {
         LIFX.exit()
     }
 }
-
-LIFX.main()


### PR DESCRIPTION
Removed the build warning by renaming the executable file to `LIFX` and using Swift 5.4 `@main` annotation.
